### PR TITLE
Add Konsumr to Manga

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - 📚 [MangaPill](https://mangapill.com) - Clean, ad-light reader with an extensive manga archive.
 - 📚 [MangaReader](https://mangareader.to) - High-quality manga with multiple server options and tracking features.
 - 📚 [ReadComic](https://readcomiconline.li) - Large library of Western comics alongside manga titles.
+- 📚 [Konsumr](https://konsumr.com) - Free manga collection tracker with physical edition volume-level tracking, ownership management, and release calendar.
 
 [↑ Back to top](#-table-of-contents)
 ---

--- a/data/listings.json
+++ b/data/listings.json
@@ -228,6 +228,11 @@
           "name": "ReadComic",
           "url": "https://readcomiconline.li",
           "description": "Large library of Western comics alongside manga titles."
+        },
+        {
+          "name": "Konsumr",
+          "url": "https://konsumr.com",
+          "description": "Free manga collection tracker with physical edition volume-level tracking, ownership management, and release calendar."
         }
       ]
     },

--- a/website/docs/manga.md
+++ b/website/docs/manga.md
@@ -16,3 +16,4 @@ sidebar_position: 5
 - 📚 [MangaPill](https://mangapill.com) - Clean, ad-light reader with an extensive manga archive.
 - 📚 [MangaReader](https://mangareader.to) - High-quality manga with multiple server options and tracking features.
 - 📚 [ReadComic](https://readcomiconline.li) - Large library of Western comics alongside manga titles.
+- 📚 [Konsumr](https://konsumr.com) - Free manga collection tracker with physical edition volume-level tracking, ownership management, and release calendar.


### PR DESCRIPTION
Adds [Konsumr](https://konsumr.com) to the Manga section — the section covers where to read; Konsumr covers keeping track of what you own and read:

- Physical manga collections tracked at the edition level (Standard, Deluxe, Omnibus, Box Sets), with real volume covers, ISBNs, release dates, a missing-volumes list and a release calendar
- Also tracks anime, TV and movies episode-by-episode with season progress and watchlists
- Imports from AniList, MyAnimeList, Trakt, TV Time, Simkl, Letterboxd, IMDb and spreadsheets; full JSON export anytime
- Web app plus native iOS app with Home Screen widgets: https://apps.apple.com/in/app/konsumr/id6777552181 (Google Play coming soon)
- Free — no ads, no volume caps, no premium tier

Edited `data/listings.json` and ran `website/scripts/generate-content.mjs` to regenerate `README.md` and `website/docs/manga.md`.