### PR TITLE
⚡ Bolt: Use Latin font subsets to reduce CSS bundle size by ~82%

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-30 - Fontsource full font CSS import bloat
+**Learning:** Default Fontsource CSS imports (e.g., `@import '@fontsource/inter/400.css'`) load `@font-face` definitions for all supported character sets (Cyrillic, Greek, Vietnamese, Latin, etc.), bundling hundreds of kilobytes of unused CSS rules.
+**Action:** For sites that primarily render Latin script, use language-specific subset imports (e.g., `@import '@fontsource/inter/latin-400.css'`) to eliminate unused `@font-face` declarations and dramatically shrink the render-blocking CSS bundle size.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2026-03-30 - Fontsource full font CSS import bloat
-**Learning:** Default Fontsource CSS imports (e.g., `@import '@fontsource/inter/400.css'`) load `@font-face` definitions for all supported character sets (Cyrillic, Greek, Vietnamese, Latin, etc.), bundling hundreds of kilobytes of unused CSS rules.
-**Action:** For sites that primarily render Latin script, use language-specific subset imports (e.g., `@import '@fontsource/inter/latin-400.css'`) to eliminate unused `@font-face` declarations and dramatically shrink the render-blocking CSS bundle size.

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -3,13 +3,18 @@
  * Establishes root design tokens, theming variables, and core layout modifications.
  */
 
-/* Self-hosted fonts (no external network requests) */
-@import '@fontsource/inter/400.css';
-@import '@fontsource/inter/500.css';
-@import '@fontsource/inter/600.css';
-@import '@fontsource/inter/700.css';
-@import '@fontsource/jetbrains-mono/400.css';
-@import '@fontsource/jetbrains-mono/500.css';
+/*
+ * Performance Optimization (Bolt):
+ * Import Latin-only font subsets from Fontsource instead of full multi-script CSS files.
+ * Full font imports include @font-face definitions for Cyrillic, Greek, Vietnamese, etc.,
+ * which bloated the generated CSS bundle by ~418 KB (82% reduction, from ~510 KB down to ~92 KB).
+ */
+@import '@fontsource/inter/latin-400.css';
+@import '@fontsource/inter/latin-500.css';
+@import '@fontsource/inter/latin-600.css';
+@import '@fontsource/inter/latin-700.css';
+@import '@fontsource/jetbrains-mono/latin-400.css';
+@import '@fontsource/jetbrains-mono/latin-500.css';
 
 :root {
   --ifm-color-primary: #d71921;


### PR DESCRIPTION
💡 What: Replaced default Fontsource CSS imports (`@fontsource/inter/*.css` and `@fontsource/jetbrains-mono/*.css`) with Latin-specific subset imports (`@fontsource/inter/latin-*.css` and `@fontsource/jetbrains-mono/latin-*.css`).

🎯 Why: Default Fontsource imports bundle `@font-face` definitions for every supported script (Cyrillic, Greek, Vietnamese, etc.), generating 40 `@font-face` rules when only 12 Latin rules are needed for the site content. This bloated the static CSS bundle significantly.

📊 Impact:
- Reduces static CSS bundle size from ~510 KB down to ~91 KB (~82% reduction, eliminating ~418 KB of unneeded CSS).
- Improves page load performance, FCP (First Contentful Paint), and rendering efficiency by delivering a much lighter critical CSS file.

🔬 Measurement:
- Verified via `npm run build` in `website`: bundle size dropped from 510 KB (`styles.88676565.css`) to 91 KB (`styles.e376a9ca.css`).
- Ran `npm run typecheck` to verify no TypeScript or build issues.

---
*PR created automatically by Jules for task [14313930646736453405](https://jules.google.com/task/14313930646736453405) started by @OshekharO*